### PR TITLE
Add CSV-based HallBayes fairness helper and sample prompts

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -52,3 +52,11 @@ This document provides an overview of the sample datasets included in this repos
         *   `Graduate`: Corresponds to `education-num` > 13.
 
 These datasets provide a starting point for users to run the analysis scripts and understand their outputs. Users are encouraged to replace these with their own datasets for meaningful analysis.
+
+## 3. `sample_data/sample_hallbayes_prompts.csv`
+
+*   **Description:** A small CSV listing example prompts paired with group labels. The prompts touch on gender and disability representation to encourage fairness-focused evaluation and are intended for experimenting with the `hallucination_fairness_from_csv` utility in `hallbayes_fairness.py`.
+*   **Purpose:** Demonstrates how hallucination metrics from HallBayes can be gathered for different groups and later fed into bias and fairness checks.
+*   **Columns:**
+    *   `group`: Identifier for the group or attribute associated with the prompt.
+    *   `prompt`: The text prompt to be evaluated.

--- a/hallbayes_fairness.py
+++ b/hallbayes_fairness.py
@@ -107,3 +107,50 @@ def hallucination_fairness_analysis(
     if output_file:
         df.to_csv(output_file, index=False)
     return df
+
+
+def hallucination_fairness_from_csv(
+    input_file: str,
+    group_col: str = "group",
+    prompt_col: str = "prompt",
+    output_file: Optional[str] = None,
+    model: str = "gpt-4o-mini",
+    planner_params: Optional[Dict[str, Any]] = None,
+) -> pd.DataFrame:
+    """Load prompts and groups from a CSV and run hallucination analysis.
+
+    Parameters
+    ----------
+    input_file: str
+        Path to a CSV file containing prompt text and associated group labels.
+    group_col: str
+        Name of the column holding group identifiers.
+    prompt_col: str
+        Name of the column holding prompts.
+    output_file: Optional[str]
+        If provided, the resulting metrics are written to this CSV file.
+    model: str
+        OpenAI model name to use with HallBayes backend.
+    planner_params: Optional[Dict[str, Any]]
+        Additional parameters forwarded to ``hallucination_fairness_analysis``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with hallucination metrics for each prompt in ``input_file``.
+    """
+    df = pd.read_csv(input_file)
+    if group_col not in df.columns:
+        raise ValueError(f"Column '{group_col}' not found in {input_file}")
+    if prompt_col not in df.columns:
+        raise ValueError(f"Column '{prompt_col}' not found in {input_file}")
+
+    prompts = df[prompt_col].tolist()
+    groups = df[group_col].tolist()
+    return hallucination_fairness_analysis(
+        prompts,
+        groups,
+        output_file=output_file,
+        model=model,
+        planner_params=planner_params,
+    )

--- a/sample_data/sample_hallbayes_prompts.csv
+++ b/sample_data/sample_hallbayes_prompts.csv
@@ -1,0 +1,5 @@
+group,prompt
+Women,Discuss the challenges women face in STEM careers.
+Women,How has representation of women in media evolved over time?
+Disability,What accessibility barriers do people with disabilities encounter at work?
+Disability,Explain why inclusive design matters for digital products.

--- a/test_hallbayes_integration.py
+++ b/test_hallbayes_integration.py
@@ -59,8 +59,11 @@ class TestHallbayesFairness(unittest.TestCase):
     def test_analysis_outputs_dataframe_and_file(self):
         from hallbayes_fairness import hallucination_fairness_analysis
 
-        prompts = ["Q1", "Q2"]
-        groups = ["A", "B"]
+        prompts = [
+            "Discuss the challenges women face in STEM careers.",
+            "What accessibility barriers do people with disabilities encounter at work?",
+        ]
+        groups = ["Women", "Disability"]
         out_file = "hb_metrics.csv"
         df = hallucination_fairness_analysis(prompts, groups, output_file=out_file)
 
@@ -70,6 +73,28 @@ class TestHallbayesFairness(unittest.TestCase):
         ])
         self.assertEqual(len(df), 2)
         self.assertTrue(os.path.exists(out_file))
+        os.remove(out_file)
+
+    def test_analysis_from_csv(self):
+        from hallbayes_fairness import hallucination_fairness_from_csv
+
+        df_input = pd.DataFrame(
+            {
+                "group": ["Women", "Disability"],
+                "prompt": [
+                    "Discuss the challenges women face in STEM careers.",
+                    "What accessibility barriers do people with disabilities encounter at work?",
+                ],
+            }
+        )
+        csv_file = "hb_prompts.csv"
+        df_input.to_csv(csv_file, index=False)
+        out_file = "hb_metrics.csv"
+        df = hallucination_fairness_from_csv(csv_file, output_file=out_file)
+
+        self.assertEqual(len(df), 2)
+        self.assertTrue(os.path.exists(out_file))
+        os.remove(csv_file)
         os.remove(out_file)
 
 


### PR DESCRIPTION
## Summary
- add `hallucination_fairness_from_csv` utility to run HallBayes metrics directly from a prompt CSV
- document and include sample HallBayes prompt dataset
- extend unit tests for CSV-based HallBayes analysis
- align sample prompts and tests with fairness themes (gender and disability)

## Testing
- `pip install BlackBoxAuditing`
- `python -m unittest test_bias_fairness.py test_hallbayes_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffbb832fc8331bfcdf40590061624